### PR TITLE
Fix recurrent substitution issues with tibbles in check_latex

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,16 +2,16 @@
 #### Change special LaTeX symbols
 
 check_latex<- function(df = NULL, column=NULL){
-  df[,column] <- gsub("&", "\\\\&", df[,column])
-  df[,column] <- gsub("%", "\\%", df[,column])
+  df[[column]] <- gsub("&", "\\\\&", df[[column]])
+  df[[column]] <- gsub("%", "\\%", df[[column]])
   # df[,column] <- gsub("$", "\\$", df[,column])#added to all texts at the end
-  df[,column] <- gsub("#", "\\#", df[,column])
-  df[,column] <- gsub("_", "\\_", df[,column]) #document names get truncated
+  df[[column]] <- gsub("#", "\\#", df[[column]])
+  df[[column]] <- gsub("_", "\\_", df[[column]]) #document names get truncated
   # df[,column] <- gsub("{", "\\{", df[,column]) #document names get truncated
-  df[,column] <- gsub("}", "\\}", df[,column])
-  df[,column] <- gsub("~", "-"  , df[,column]) #unable to render with \\~
-  df[,column] <- gsub("\\^", "\\\\^"  , df[,column])#name truncated and accent to the next letter
-  return(df[,column])
+  df[[column]] <- gsub("}", "\\}", df[[column]])
+  df[[column]] <- gsub("~", "-"  , df[[column]]) #unable to render with \\~
+  df[[column]] <- gsub("\\^", "\\\\^"  , df[[column]])#name truncated and accent to the next letter
+  return(df[[column]])
 }
 
 


### PR DESCRIPTION
If the data frame given as input for either of the functions running `check_latex` is a tibble, then the gsub in `check_latex()` start with recurrent substitutions of "/" characters and ultimately an almost endless project that gobbles up memory until R crashes (or anyway, one wouldn't get anything resembling the desired output). 

Tibbles are very common, as they are the default output of common functions such as `readr::read_csv` or `googlesheets4::read_sheet` and many other packages.

The problem can be easily solved by selecting columns in a way that is compatible to both base R and tibbles, basically replacing `df[,column]` with `df[[column]]`

``` r
library("labeleR")
column <- "List"
df <- badges.table
gsub("&", "\\\\&", df[,column])
#> [1] "Cornelius Fudge"    "Rita Skeeter"       "Bartemius Crouch"  
#> [4] "Newt Scamander"     "Garrick Ollivander" "Lily Potter"       
#> [7] "Peter Pettigrew"    "Sirius Black"

df <- tibble::as_tibble(badges.table)
gsub("&", "\\\\&", df[,column])
#> [1] "c(\"Cornelius Fudge\", \"Rita Skeeter\", \"Bartemius Crouch\", \"Newt Scamander\", \"Garrick Ollivander\", \"Lily Potter\", \"Peter Pettigrew\", \"Sirius Black\")"

# see output, and with every gsub the mess will only grow, and very quickly

# the following may run for very long:
# check_latex(tibble::as_tibble(badges.table), "List")
```

<sup>Created on 2023-12-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>